### PR TITLE
Fixes selected date for custom dates and mmm format

### DIFF
--- a/src/ngx-my-date-picker/services/ngx-my-date-picker.util.service.ts
+++ b/src/ngx-my-date-picker/services/ngx-my-date-picker.util.service.ts
@@ -14,7 +14,7 @@ export class UtilService {
         let isMonthStr: boolean = dateFormat.indexOf("mmm") !== -1;
         let returnDate: IMyDate = {day: 0, month: 0, year: 0};
 
-        if (dateStr.length !== dateFormat.length) {
+        if (dateStr.length !== dateFormat.length && !isMonthStr) {
             return returnDate;
         }
 
@@ -25,9 +25,9 @@ export class UtilService {
             return returnDate;
         }
 
-        let day: number = this.parseDatePartNumber(dateFormat, dateStr, "dd");
         let month: number = isMonthStr ? this.parseDatePartMonthName(dateFormat, dateStr, "mmm", monthLabels) : this.parseDatePartNumber(dateFormat, dateStr, "mm");
-        let year: number = this.parseDatePartNumber(dateFormat, dateStr, "yyyy");
+        let day: number = this.parseDatePartNumber(dateFormat, dateStr, "dd", monthLabels[month]);
+        let year: number = this.parseDatePartNumber(dateFormat, dateStr, "yyyy", monthLabels[month]);
 
         if (day !== -1 && month !== -1 && year !== -1) {
             if (year < minYear || year > maxYear || month < 1 || month > 12) {
@@ -56,7 +56,7 @@ export class UtilService {
 
     isMonthLabelValid(monthLabel: string, monthLabels: IMyMonthLabels): number {
         for (let key = 1; key <= 12; key++) {
-            if (monthLabel.toLowerCase() === monthLabels[key].toLowerCase()) {
+            if (monthLabels[key].toLowerCase().indexOf(monthLabel.toLowerCase()) !== -1) {
                 return key;
             }
         }
@@ -70,9 +70,13 @@ export class UtilService {
         return -1;
     }
 
-    parseDatePartNumber(dateFormat: string, dateString: string, datePart: string): number {
+    parseDatePartNumber(dateFormat: string, dateString: string, datePart: string, monthLabel?: string): number {
         let pos: number = dateFormat.indexOf(datePart);
         if (pos !== -1) {
+            var monthStrPos = dateFormat.indexOf('mmm');
+            if (monthStrPos !== -1 && monthLabel) {
+                pos += (monthLabel.length - 'mmm'.length);
+            }
             let value: string = dateString.substring(pos, pos + datePart.length);
             if (!/^\d+$/.test(value)) {
                 return -1;


### PR DESCRIPTION
When using a custom date format with custom months the `.selectedday` class did not apply.

This was due to several reasons:
- First check of `isDateValid` would have returned back the default date
- `isMonthLabelValid` would never have matched `Apr` against `April`
- `parseDatePartNumber` could not offset the substring correctly for when the month name was longer than the format (mmm). 

Note: I included `'mmm'.length` to provide context to what the offset was for (instead of just - 3). 

These were the options: 
```
private datePickerOptions: IMyOptions = {
        dateFormat: 'mmm dd, yyyy',
        editableMonthAndYear: false,
        minYear: 2017,
        showTodayBtn: false,
        monthLabels: {
            1: 'January',
            2: 'February',
            3: 'March',
            4: 'April',
            5: 'May',
            6: 'June',
            7: 'July',
            8: 'August',
            9: 'September',
            10: 'October',
            11: 'November',
            12: 'December'
        },
        sunHighlight: false
    };
```

Template snippet:
```
<input class="form-control" ngx-mydatepicker
    [placeholder]="'Publish At' | translate"
    formControlName="publishAt"
    [options]="datePickerOptions"
    #publishAt="ngx-mydatepicker"/>
<span loopIcon="calendar"
    (click)="publishAt.openCalendar()"></span>
```

Behavior:
![screen shot 2017-04-21 at 1 17 23 am](https://cloud.githubusercontent.com/assets/13732623/25263821/63b1453e-2630-11e7-8068-c463d8364cc8.png)

Expected Behavior:
![screen shot 2017-04-21 at 2 17 37 am](https://cloud.githubusercontent.com/assets/13732623/25265026/c090bb38-2638-11e7-8021-2243d142a59a.png)

