### PR TITLE
NgxMyDatePickerDirective causes unnecessary AppView.detectChanges's at every click in the document for every element with this directive.

### DIFF
--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -96,7 +96,11 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
         this.onTouchedCb();
     }
 
-    @HostListener("document:click", ["$event"]) onClick(evt: MouseEvent) {
+    //wrapper with arrow function to preserve the use of 'this' word
+    private onClickWrapper = (ev: MouseEvent) => { this.onClick(ev); };
+    
+    //@HostListener("document:click", ["$event"])
+    onClick(evt: MouseEvent) {
         if (this.opts.closeSelectorOnDocumentClick && !this.preventClose && evt.target && this.cRef !== null && this.elem.nativeElement !== evt.target && !this.cRef.location.nativeElement.contains(evt.target) && !this.disabled) {
             this.closeSelector(CalToggle.CloseByOutClick);
         }
@@ -219,9 +223,11 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
             return;
         }
         if (this.cRef === null) {
-            this.openCalendar();
+            document.addEventListener('click', this.onClickWrapper);
+            this.openCalendar();            
         }
         else {
+            document.removeEventListener('click', this.onClickWrapper);
             this.closeSelector(CalToggle.CloseByCalBtn);
         }
     }


### PR DESCRIPTION
  [NgxMyDatePickerDirective causes unnecessary AppView.detectChanges's at every click in the document for every element with this directive.]
  Although no bind has occurred, AppView.detectChanges can take considerable time in pages with many bindable elements.
  In "sample-date-picker-ngmodel.html" I changed it to create 18 NgxMyDatePickerDirective, the result of "document.click" can be seen in this images:
![schennshot-2018-01-04 14-11-11](https://user-images.githubusercontent.com/1711296/34576869-1800e244-f15e-11e7-876c-739e99364c19.png)
![schennshot-2018-01-04 14-11-27](https://user-images.githubusercontent.com/1711296/34576870-182705fa-f15e-11e7-9e00-9671edd589dc.png)
Related issue: [#120](https://github.com/kekeh/ngx-mydatepicker/issues/120)
#120
  