### PR TITLE
fix: validate control when options change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mydatepicker",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Angular date picker",
   "keywords": [
     "Angular",

--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -131,6 +131,7 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
         if (this.opts.maxYear > Year.max) {
             this.opts.maxYear = Year.max;
         }
+        this.validate(undefined);
     }
 
     public writeValue(value: any): void {
@@ -268,9 +269,9 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
     }
 
     private updateModel(model: IMyDateModel): void {
+        this.setInputValue(model.formatted);
         this.onChangeCb(model);
         this.onTouchedCb();
-        this.setInputValue(model.formatted);
     }
 
     private setInputValue(value: string): void {


### PR DESCRIPTION
[ngx-my-date-picker.input](https://github.com/kekeh/ngx-mydatepicker/blob/master/src/ngx-my-date-picker/ngx-my-date-picker.input.ts#L270) has an update method which updates value in the native input and calls `onChangeCb`. However it first calls the callback with the current model and after calling callback it sets the value into native input:

```
this.onChangeCb(model);
this.onTouchedCb();
this.setInputValue(model.formatted);
```

`this.onChangeCb(model);` triggers validation, and validate method uses `this.elem.nativeElement.value`, but native element still contains previous value as it is updated in `setInputValue` method.
Simply reordering the calls in updateModel method fixes the problem.

Second issue that is fixed with this PR is that when options input change, then it is necessary to revalidate the datepicker, as some option changes might invalidate the value.