### PR TITLE
fix: revalidate form control when options input change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mydatepicker",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Angular date picker",
   "keywords": [
     "Angular",

--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -84,6 +84,7 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
                         this.clearDate();
                     }
                     else {
+                        this.model = null;
                         this.onChangeCb(null);
                         this.emitInputFieldChanged(this.elem.nativeElement.value, false);
                     }
@@ -241,6 +242,7 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
         }
         this.emitDateChanged({date: {year: 0, month: 0, day: 0}, jsdate: null, formatted: "", epoc: 0});
         this.emitInputFieldChanged("", false);
+        this.model = null;
         this.onChangeCb(null);
         this.onTouchedCb();
         this.setInputValue("");

--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -41,6 +41,7 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
     private disabled = false;
 
     private opts: IMyOptions;
+    private model: IMyDateModel;
 
     onChangeCb: (_: any) => void = () => { };
     onTouchedCb: () => void = () => { };
@@ -108,6 +109,9 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
     public ngOnChanges(changes: SimpleChanges): void {
         if (changes.hasOwnProperty("options")) {
             this.parseOptions(changes["options"].currentValue);
+            if (!changes["options"].isFirstChange()) {
+                this.onChangeCb(this.model);
+            }
         }
 
         if (changes.hasOwnProperty("defaultMonth")) {
@@ -131,7 +135,6 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
         if (this.opts.maxYear > Year.max) {
             this.opts.maxYear = Year.max;
         }
-        this.validate(undefined);
     }
 
     public writeValue(value: any): void {
@@ -269,6 +272,7 @@ export class NgxMyDatePickerDirective implements OnChanges, ControlValueAccessor
     }
 
     private updateModel(model: IMyDateModel): void {
+        this.model = model;
         this.setInputValue(model.formatted);
         this.onChangeCb(model);
         this.onTouchedCb();


### PR DESCRIPTION
PR #121 didn't really fixed issue with revalidation of form control when option changed as we need angular to call the validation function. In my case it worked as i manually called `updateValueAndValidity` after changing the options, but i wanted to prevent that unnecessary call.

I have asked [question on stackoverflow](https://stackoverflow.com/questions/48163891/trigger-custom-form-control-validation-on-input-change) how to properly revalidate custom form control and implemented proposed solution.

What do you think?