### PR TITLE
Show date in disabled input

### DIFF
--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -138,17 +138,15 @@ export class NgxMyDatePickerDirective implements OnChanges, OnDestroy, ControlVa
     }
 
     public writeValue(value: any): void {
-        if (!this.disabled) {
-            if (value && (value["date"] || value["jsdate"])) {
-                let formatted: string = this.utilService.formatDate(value["date"] ? value["date"] : this.jsDateToMyDate(value["jsdate"]), this.opts.dateFormat, this.opts.monthLabels);
-                let date: IMyDate = this.utilService.isDateValid(formatted, this.opts.dateFormat, this.opts.minYear, this.opts.maxYear, this.opts.disableUntil, this.opts.disableSince, this.opts.disableWeekends, this.opts.disableDates, this.opts.disableDateRanges, this.opts.disableWeekdays, this.opts.monthLabels, this.opts.enableDates);
-                this.setInputValue(formatted);
-                this.emitInputFieldChanged(formatted, this.utilService.isInitializedDate(date));
-            }
-            else if (value === null || value === "") {
-                this.setInputValue("");
-                this.emitInputFieldChanged("", false);
-            }
+        if (value && (value["date"] || value["jsdate"])) {
+            let formatted: string = this.utilService.formatDate(value["date"] ? value["date"] : this.jsDateToMyDate(value["jsdate"]), this.opts.dateFormat, this.opts.monthLabels);
+            let date: IMyDate = this.utilService.isDateValid(formatted, this.opts.dateFormat, this.opts.minYear, this.opts.maxYear, this.opts.disableUntil, this.opts.disableSince, this.opts.disableWeekends, this.opts.disableDates, this.opts.disableDateRanges, this.opts.disableWeekdays, this.opts.monthLabels, this.opts.enableDates);
+            this.setInputValue(formatted);
+            this.emitInputFieldChanged(formatted, this.utilService.isInitializedDate(date));
+        }
+        else if (value === null || value === "") {
+            this.setInputValue("");
+            this.emitInputFieldChanged("", false);
         }
     }
 


### PR DESCRIPTION
`emitInputFieldChanged` already has a disabled check, so it's not needed in `writeValue`. It causes problems because if a user wants to show a disabled form with data, then the datepicker input will always show up empty because when the field is disabled, then the input won't display the date.

Fixes [this issue](https://github.com/kekeh/ngx-mydatepicker/issues/29#issuecomment-414687830) on #29, not sure if it actually fixes 29 itself or not.