### PR TITLE
Ensure click event listener is always removed

### DIFF
--- a/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.input.ts
@@ -120,6 +120,7 @@ export class NgxMyDatePickerDirective implements OnChanges, OnDestroy, ControlVa
 
     public ngOnDestroy(): void {
         this.closeCalendar();
+        document.removeEventListener("click", this.onClickWrapper);
     }
 
     public parseOptions(opts: IMyOptions): void {


### PR DESCRIPTION
The toggleCalendar() function adds/removes the event listener when called.
However, selecting a data from the calendar does not result in a call to
toggleCalendar() to close the calendar, which in turn means that the
call to removeEventListener() there is not executed.

Adding a removeEventListener() to the ngOnDestroy() call ensures that
the listener is always cleaned up.