### PR TITLE
Explicity type for forRoot() ModuleWithProviders

### DIFF
--- a/src/ngx-my-date-picker/ngx-my-date-picker.module.ts
+++ b/src/ngx-my-date-picker/ngx-my-date-picker.module.ts
@@ -13,7 +13,7 @@ import { NgxMyDatePickerConfig } from "./services/ngx-my-date-picker.config";
     exports: [NgxMyDatePicker, NgxMyDatePickerDirective, FocusDirective]
 })
 export class NgxMyDatePickerModule {
-    static forRoot(): ModuleWithProviders {
+    static forRoot(): ModuleWithProviders<NgxMyDatePickerModule> {
         return {
             ngModule: NgxMyDatePickerModule,
             providers: [NgxMyDatePickerConfig]


### PR DESCRIPTION
For builds on Angular 9+.